### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server that enables Large Language Models (LLMs) to interact with JIRA through standardized tools and context. This server provides capabilities for searching issues using JQL and retrieving detailed issue information.
 
+<a href="https://glama.ai/mcp/servers/4e3sqj7af1"><img width="380" height="200" src="https://glama.ai/mcp/servers/4e3sqj7af1/badge" alt="jira-mcp MCP server" /></a>
+
 ## Features
 
 - **JQL Search**: Execute complex JQL queries with pagination support


### PR DESCRIPTION
This PR adds a badge for the jira-mcp server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4e3sqj7af1"><img width="380" height="200" src="https://glama.ai/mcp/servers/4e3sqj7af1/badge" alt="jira-mcp MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.